### PR TITLE
modify assign roles.

### DIFF
--- a/server/logic/modules/assignRoles.js
+++ b/server/logic/modules/assignRoles.js
@@ -40,11 +40,11 @@ module.exports.assignRoles = function(memcache, socket) {
       memcache.setRole(party.minions[y], 'MINION');
     }
     if (party.merlin) {
-      data['merlin'] = party.merlin;
+      data[party.merlin] = 'MERLIN';
       memcache.setMerlin(party.merlin);
     }
     if (party.assassin) {
-      data['assassin'] = party.assassin;
+      data[party.assassin] = 'ASSASSIN';
       memcache.setAssassin(party.assassin);
     }
 


### PR DESCRIPTION
playerID's are now associated with merlin/assassin instead of a separate merlin/assassin property when returning data to the client for role assignment. 
